### PR TITLE
fix: Potential fix for code scanning alert no. 25: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -5,6 +5,9 @@
        - main
  jobs:
    release-please:
+     permissions:
+       contents: write
+       pull-requests: write
      runs-on: ubuntu-latest
      steps:
        - uses: googleapis/release-please-action@v4.3.0


### PR DESCRIPTION
Potential fix for [https://github.com/openfoodfacts/OFFMassUpdate/security/code-scanning/25](https://github.com/openfoodfacts/OFFMassUpdate/security/code-scanning/25)

To fix the problem, you should add a `permissions` block to the workflow, configuring the minimum privileges required by the `release-please-action`. According to the [release-please-action docs](https://github.com/googleapis/release-please-action#github-token-permissions), the action needs `contents: write` (to create tags and releases) and `pull-requests: write` (to open release PRs).  
The best way is to add a `permissions` mapping under the job (recommended for granularity), specifically for the `release-please` job, setting:

```yaml
permissions:
  contents: write
  pull-requests: write
```

Insert this block between `release-please:` and `runs-on:` in the workflow, for job-specific least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
