### PR TITLE
Potential fix for code scanning alert no. 27: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -15,6 +15,9 @@ jobs:
   main:
     name: Validate PR title
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: amannn/action-semantic-pull-request@v6
         env:


### PR DESCRIPTION
Potential fix for [https://github.com/openfoodfacts/OFFMassUpdate/security/code-scanning/27](https://github.com/openfoodfacts/OFFMassUpdate/security/code-scanning/27)

To fix this issue, add a `permissions` key to either the job (preferred for specificity) or to the root of the workflow in `.github/workflows/semantic-pr.yml`. In this context, set `contents: read` (for reading data about the repo/PR) and `pull-requests: write` (to allow the action to annotate, approve, or comment on PRs if needed). This change should appear within the `main:` job block, above `steps:`, or at the top-level. No code outside `.github/workflows/semantic-pr.yml` needs to be modified.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
