### PR TITLE
Potential fix for code scanning alert no. 24: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/github-projects.yml
+++ b/.github/workflows/github-projects.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   add-to-project:
     name: Add issue to project
+    permissions:
+      issues: read
+      projects: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/add-to-project@main


### PR DESCRIPTION
Potential fix for [https://github.com/openfoodfacts/OFFMassUpdate/security/code-scanning/24](https://github.com/openfoodfacts/OFFMassUpdate/security/code-scanning/24)

The best way to fix this problem is to add an explicit `permissions` block to the workflow or to the jobs in the workflow, granting only the required minimal permissions. Since this workflow adds issues to GitHub Projects in response to events related to issues, the likely minimal permissions are `issues: read` and possibly `projects: write` or `projects: read` if modifying projects. Since the "add-to-project" action often requires some write capability to modify projects (add cards/issues), `projects: write` is appropriate. The `contents` permission is not needed unless files are read/written; in this scenario they are not. You should add a `permissions` block to the job `add-to-project` (line 10) or to the root of the workflow (above `jobs`).

**Required changes:**
- In `.github/workflows/github-projects.yml`, insert under the `jobs > add-to-project` key a `permissions` block specifying `issues: read` and `projects: write`.
- No additional methods or imports are necessary.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
